### PR TITLE
Updated usage of Skybot

### DIFF
--- a/gmadet/config/FRAM-Auger/hotpants.hjson
+++ b/gmadet/config/FRAM-Auger/hotpants.hjson
@@ -62,7 +62,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/IRIS/hotpants.hjson
+++ b/gmadet/config/IRIS/hotpants.hjson
@@ -59,7 +59,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/KAIT/hotpants.hjson
+++ b/gmadet/config/KAIT/hotpants.hjson
@@ -57,7 +57,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/Lisniky-AZT8/hotpants.hjson
+++ b/gmadet/config/Lisniky-AZT8/hotpants.hjson
@@ -57,7 +57,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/OAJ-T80/hotpants.hjson
+++ b/gmadet/config/OAJ-T80/hotpants.hjson
@@ -60,7 +60,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/PS1/hotpants.hjson
+++ b/gmadet/config/PS1/hotpants.hjson
@@ -59,7 +59,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/TCA/hotpants.hjson
+++ b/gmadet/config/TCA/hotpants.hjson
@@ -60,7 +60,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/TCH/hotpants.hjson
+++ b/gmadet/config/TCH/hotpants.hjson
@@ -60,7 +60,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/TRE/hotpants.hjson
+++ b/gmadet/config/TRE/hotpants.hjson
@@ -60,7 +60,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/UBAI-T60N/hotpants.hjson
+++ b/gmadet/config/UBAI-T60N/hotpants.hjson
@@ -57,7 +57,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/config/UBAI-T60S/hotpants.hjson
+++ b/gmadet/config/UBAI-T60S/hotpants.hjson
@@ -57,7 +57,7 @@ fi: 1.0e-30
 mous: 1
 
 # verbosity: level of verbosity, 0-2, default: 1
-v: 1
+v: 0
 
 
 }

--- a/gmadet/crossmatch.py
+++ b/gmadet/crossmatch.py
@@ -526,12 +526,25 @@ def moving_objects(candidates):
         % (len(candidates[candidates['movingObjMatch'] == 'Y']))
     )
 
+    # Set up output path and file names
+    path, fname_ext = os.path.split(candidates['OriginalIma'][0])
+    if path:
+        folder = path + "/"
+    else:
+        folder = ""
+    # Get rid of the extension to keep only the name
+    fname2, extension = os.path.splitext(fname_ext)
+    # Get rid of the _reg suffix
+    fname2 = fname2.split('_reg')[0]
+
     if moving_objects_tot is not None:
         moving_objects_tot.write(
-            "moving_objects.dat", format="ascii.commented_header", overwrite=True
+            folder + fname2 + "_moving_objects.dat",
+            format="ascii.commented_header", overwrite=True
         )
         moving_objects_tot["RA", "DEC"].write(
-            "moving_objects.reg", format="ascii.commented_header", overwrite=True
+            folder + fname2 + "_moving_objects.reg",
+            format="ascii.commented_header", overwrite=True
         )
 
     return candidates

--- a/gmadet/crossmatch.py
+++ b/gmadet/crossmatch.py
@@ -424,19 +424,30 @@ def crossmatch_skybot(sources, moving_objects, radius=10):
     dist_match = dist[match]
     #  Convert in arcseconds
     dist_match *= 3600
-    if dist_match:
+    if len(dist_match) > 0:
         mov_match = moving_objects[ind[match]]
-        sources[match]['movingObjMatch'] = 'Y'
-        sources[match]['movingObjSep'] = dist_match * 3600
-        sources[match]['movingObjName'] = mov_match['Name']
+        movingObjMatch_list = []
+        movingObjSep_list = []
+        movingObjName = []
+        for j in range(len(mov_match)):
+            movingObjMatch_list.append('Y')
+            movingObjSep_list.append(dist_match[j])
+            movingObjName.append(mov_match['Name'][j])
+        sources['movingObjMatch'][match] = movingObjMatch_list
+        sources['movingObjSep'][match] = movingObjSep_list
+        sources['movingObjName'][match] = movingObjName
     return sources
 
 
-def moving_objects(candidates):
+def moving_objects(candidates, radius_cross=10):
     """
     Crossmatch the list of candidates with moving objects using SkyBoT
     Loop over each image in the candidates table.
     Run a SkyBot search on each.
+    radisu_cross is the radius crossmatch between transient candidates and 
+    list of solar objects (in arcseconds). By default: 10 because the 
+    crossmatch is made at a single time defined by DATE-OBS, so this allows
+    for flexibility.
     """
     # Initialise with None
     moving_objects_tot = None
@@ -446,7 +457,7 @@ def moving_objects(candidates):
                               name="movingObjMatch")
     moving_obj_sep = Column([None] * len(candidates),
                               name="movingObjSep")
-    moving_obj_name = Column(['None'] * len(candidates),
+    moving_obj_name = Column([None] * len(candidates),
                               name="movingObjName")
     candidates.add_columns([moving_obj_match,
                             moving_obj_sep,
@@ -515,11 +526,11 @@ def moving_objects(candidates):
                 moving_objects_tot = vstack([moving_objects_tot,
                                              moving_objects])
 
-        candidates_matched = crossmatch_skybot(
-            candidates[mask], moving_objects, radius=10)
+            candidates_matched = crossmatch_skybot(
+                candidates[mask], moving_objects, radius=radius_cross)
 
-        # Update candidates table
-        candidates[mask] = candidates_matched
+            # Update candidates table
+            candidates[mask] = candidates_matched
 
     print(
         "%d match with a moving object found around 10 arcseconds."

--- a/gmadet/phot_calibration.py
+++ b/gmadet/phot_calibration.py
@@ -314,7 +314,8 @@ def phot_calib(detected_sources, telescope, radius=3, sigma_clip=1.5,
             good_ref_sources, band_cat, catalog)
         print("Compute zeropoint.")
         ref_cat_calibrated, deltaMagMedian, deltaMagStd = zeropoint(
-           ref_cat, sigma_clip, folder, fname2, band_cat, catalogName, doPlot=True
+           ref_cat, sigma_clip, folder, fname2,
+           band_cat, catalogName, doPlot=True
         )
 
         deltaMagMedianlist.append(deltaMagMedian)
@@ -349,7 +350,8 @@ def phot_calib(detected_sources, telescope, radius=3, sigma_clip=1.5,
                 good_ref_sources[mask_key], band_cat, catalog)
             print("Compute zeropoint.")
             ref_cat_calibrated, deltaMagMedian, deltaMagStd = zeropoint(
-                ref_cat, sigma_clip, folder, fname2, band_cat, catalogName, doPlot=True
+                ref_cat, sigma_clip, folder, fname2,
+                band_cat, catalogName, doPlot=True
             )
 
             deltaMagMedianlist.append(deltaMagMedian)
@@ -392,11 +394,19 @@ def phot_calib(detected_sources, telescope, radius=3, sigma_clip=1.5,
         detected_sources["filter_cat"][mask] = band_cat_list[j] 
         detected_sources["filter_DB"][mask] = band_DB_list[j] 
 
-    fname = detected_sources['OriginalIma'][0].split("_reg_")[0] + ".alldetections"
+    fname = detected_sources['OriginalIma'][0].split("_reg_")[0] + \
+            ".alldetections"
     detected_sources.write(
         fname,
         format="ascii.commented_header",
         overwrite=True,
     )
 
-    return detected_sources
+    # Return total detected sources and sources without crossmatch
+    if subFiles is not None:
+        mask = (detected_sources["FlagSub"] == "Y") & \
+               (detected_sources["Match"] == "N")
+    else:
+        mask = detected_sources["Match"] == "N"
+
+    return detected_sources, detected_sources[mask]

--- a/gmadet/registration.py
+++ b/gmadet/registration.py
@@ -165,6 +165,7 @@ def registration(filelist, config, resultDir="", reference=None,
         refim_regist = outFiles[1]
         maskim_regist = outFiles[2]
 
+        print ('Rescale and homogeneise mask maps for bad pixels.')
         # Rescale flux to 1s
         # In the future can try to rescale flux of ref image 
         # to match input image.

--- a/gmadet/substraction.py
+++ b/gmadet/substraction.py
@@ -12,25 +12,10 @@ from astropy.coordinates import SkyCoord
 from astropy import units as u
 from gmadet.registration import registration
 from gmadet.ps1_survey import ps1_grid, prepare_PS1_sub
-from gmadet.utils import get_phot_cat, mkdir_p
+from gmadet.utils import (get_phot_cat, mkdir_p, get_corner_coords)
 from gmadet.psfex import psfex
 from gmadet.mosaic import create_mosaic
 from multiprocessing import Pool
-
-def get_corner_coords(filename):
-    """ Compute the RA, Dec coordinates at the corner of one image"""
-
-    header = fits.getheader(filename)
-    Naxis1 = header["NAXIS1"]
-    Naxis2 = header["NAXIS2"]
-
-    pix_coords = [[0, 0, Naxis1, Naxis1], [0, Naxis2, Naxis2, 0]]
-
-    # Get physical coordinates of OT
-    w = WCS(header)
-    ra, dec = w.all_pix2world(pix_coords[0], pix_coords[1], 1)
-
-    return [ra, dec]
 
 
 def substraction(filenames, reference, config, soft="hotpants",

--- a/gmadet/utils.py
+++ b/gmadet/utils.py
@@ -654,6 +654,7 @@ def clean_outputs(filenames, outLevel):
 
         rm_p(folder + "*.head")
         if outLevel == 0:
+            rm_p('coadd.weight.fits')
             rm_p(folder + "*.magwcs*")
             rm_p(folder + "*.oc*")
             rm_p(folder + "*.cat")
@@ -667,6 +668,7 @@ def clean_outputs(filenames, outLevel):
             rm_p(folder + "substraction/*segmentation")
 
         elif outLevel == 1:
+            rm_p('coadd.weight.fits')
             rm_p(folder + "*.magwcs")
             rm_p(folder + "*.oc")
             rm_p(folder + "*.cat")

--- a/gmadet/utils.py
+++ b/gmadet/utils.py
@@ -114,7 +114,7 @@ def list_files(path, pattern="*.fit*", recursive=True):
     return filenames_filtered
 
 
-def load_config(telescope, convFilter):
+def load_config(telescope, convFilter='default'):
     """Load the path to the configuration files required by the softs.
        They are telescope dependent.
     """
@@ -442,7 +442,7 @@ def get_corner_coords(filename):
     w = WCS(header)
     ra, dec = w.all_pix2world(pix_coords[0], pix_coords[1], 1)
 
-    return ra, dec
+    return [ra, dec]
 
 
 def get_phot_cat(filename, telescope):


### PR DESCRIPTION
Updated the usage of SkyBot to crossmatch transients candidates with solar objects.

Perform a cone search using the DATE-OBS time of the image, its FoV x 1.1.

Take the SkyBot list of moving objects, use their RA and Dec positions at DATE-OBS and make a crossmatch with transients candidates using a radius of 10 arcseconds.

Ideally one can use the RA_rate and Dec_rate providing by SkyBot to perform a smarter crossmatch. But this is let to future development.

Also corrected some checks that were failing when no sources are found by sextractor. 

Also set the verbose of hotpants to its minimum.